### PR TITLE
fix variable type

### DIFF
--- a/include/battery_agent.hh
+++ b/include/battery_agent.hh
@@ -45,7 +45,7 @@ public:
 private:
     int battery_level = -1;
     bool battery_charging = false;
-    int battery_approximate_level = false;
+    bool battery_approximate_level = false;
 
     IBatteryListener* battery_listener = nullptr;
 };


### PR DESCRIPTION
The variable should be changed `bool` from `int`.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>