### PR TITLE
Fix crash when setting alert while ringing

### DIFF
--- a/src/alerts_agent.cc
+++ b/src/alerts_agent.cc
@@ -328,6 +328,9 @@ void AlertsAgent::parsingSetAlert(const char* message)
 
     nugu_info("parsingSetAlert");
 
+    if (current && current->token == token)
+        stopSound("ringing-SetAlert");
+
     AlertItem* alert = manager->generateAlert(root);
     if (!alert) {
         nugu_error("internal error");
@@ -401,6 +404,9 @@ void AlertsAgent::parsingDeleteAlerts(const char* message)
         std::string token = tokens[i].asString();
 
         nugu_info("remove %d/%d: %s", i + 1, tokens.size(), token.c_str());
+
+        if (current && current->token == token)
+            stopSound("ringing-DeleteAlert");
 
         if (removeAlert(token) == true)
             list_success.push_back(token);


### PR DESCRIPTION
Fixed an issue in which the alerts agent crash if the alarm was turned
off or deleted from the mobile app while the alarm was ringing.

Signed-off-by: Inho Oh <webispy@gmail.com>