### PR TITLE
alerts: add ignored event

### DIFF
--- a/include/alerts_agent.hh
+++ b/include/alerts_agent.hh
@@ -107,7 +107,7 @@ private:
     void sendEventSetSnoozeFailed(const std::string& ps_id, const std::string& token);
     void sendEventAlertStarted(const std::string& ps_id, const std::string& token);
     void sendEventAlertFailed(const std::string& ps_id, const std::string& token, const std::string& error);
-    void sendEventAlertIgnored(const std::string& ps_id, const std::string& scheduledTime, Json::Value& alerts);
+    void sendEventAlertIgnored(const std::string& ps_id, const std::vector<std::string>& token_list);
     void sendEventAlertStopped(const std::string& ps_id, const std::string& token);
     void sendEventAlertEnteredForeground(const std::string& ps_id, const std::string& token);
     void sendEventAlertEnteredBackground(const std::string& ps_id, const std::string& token);

--- a/src/alerts_manager.hh
+++ b/src/alerts_manager.hh
@@ -20,6 +20,7 @@
 #include "alerts_agent.hh"
 
 #include <glib.h>
+#include <time.h>
 
 #define DEFAULT_ALARM_DURATION_SEC 180
 
@@ -56,6 +57,8 @@ struct _AlertItem {
     std::string token;
     bool is_activated;
     bool is_repeat;
+    bool is_ignored;
+    struct timespec creation_time;
     std::string json_str; /* original json data */
     Json::Value json;
     std::string scheduled_time;
@@ -74,6 +77,7 @@ struct _AlertItem {
     bool ignored; /* ignored by another alert item */
 
     time_t timeout_secs; /* Calculated timestamp to fire */
+    time_t secs; /* now + (timeout_secs or snooze_secs) */
 
     guint timer_src; /* GSource id */
     guint asset_timer_src; /* GSource id */

--- a/tests/test_alarm.cc
+++ b/tests/test_alarm.cc
@@ -1,5 +1,7 @@
 
 #include <glib.h>
+#include <json/json.h>
+#include <unistd.h>
 
 #include "alerts_agent.hh"
 #include "alerts_manager.hh"
@@ -30,6 +32,7 @@
 #define DIR1_WEEKDAY                            \
     "{"                                         \
     "    \"activation\" : true," REPEAT_WEEKDAY \
+    "    \"alertType\" : \"ALARM\","            \
     "    \"scheduledTime\" : \"15:07:05\","     \
     "    \"token\" : \"dir1-weekday\""          \
     "}"
@@ -37,6 +40,7 @@
 #define DIR1_WEEKDAY_SAME                       \
     "{"                                         \
     "    \"activation\" : true," REPEAT_WEEKDAY \
+    "    \"alertType\" : \"ALARM\","            \
     "    \"scheduledTime\" : \"15:07:05\","     \
     "    \"token\" : \"dir1-weekday-same\""     \
     "}"
@@ -44,6 +48,7 @@
 #define DIR1_WEEKEND                            \
     "{"                                         \
     "    \"activation\" : true," REPEAT_WEEKEND \
+    "    \"alertType\" : \"ALARM\","            \
     "    \"scheduledTime\" : \"15:07:05\","     \
     "    \"token\" : \"dir1-weekend\""          \
     "}"
@@ -51,6 +56,7 @@
 #define DIR1_NO_REPEAT_TIME                            \
     "{"                                                \
     "    \"activation\" : true,"                       \
+    "    \"alertType\" : \"ALARM\","                   \
     "    \"scheduledTime\" : \"2021-04-30T15:07:05\"," \
     "    \"token\" : \"dir1-no-repeat\""               \
     "}"
@@ -58,6 +64,7 @@
 #define DIR1_EVERYDAY                             \
     "{"                                           \
     "    \"activation\" : true," REPEAT_EVERY_DAY \
+    "    \"alertType\" : \"ALARM\","              \
     "    \"scheduledTime\" : \"15:07:05\","       \
     "    \"token\" : \"dir1-everyday\""           \
     "}"
@@ -65,6 +72,7 @@
 #define DIR1_FRIDAY_REPEAT                     \
     "{"                                        \
     "    \"activation\" : true," REPEAT_FRIDAY \
+    "    \"alertType\" : \"ALARM\","           \
     "    \"scheduledTime\" : \"15:07:05\","    \
     "    \"token\" : \"dir1-fri-repeat\""      \
     "}"
@@ -277,6 +285,185 @@ static void test_case2(void)
     g_assert(manager.add(DIR1_FRIDAY_REPEAT) == false);
 }
 
+#define DIR_TIMER                                     \
+    "{"                                               \
+    "  \"activation\" : true,"                        \
+    "  \"alertType\" : \"TIMER\","                    \
+    "  \"minDurationInSec\" : 180,"                   \
+    "  \"playServiceId\" : \"nugu.builtin.alarm\","   \
+    "  \"playStackControl\" : {"                      \
+    "    \"playServiceId\" : \"nugu.builtin.alarm\"," \
+    "    \"type\" : \"PUSH\""                         \
+    "  },"                                            \
+    "  \"scheduledTime\" : \"2021-05-12T14:25:38\","  \
+    "  \"token\" : \"token-timer\""                   \
+    "}"
+
+static void test_ignore1(void)
+{
+    AlertsManager manager;
+    const AlertItem* item;
+    Json::Value root;
+    Json::Reader reader;
+    char hms_buf[32];
+    char ymdhms_buf[64];
+    struct tm now_tm;
+    time_t now;
+
+    now = time(NULL);
+    now += 3;
+
+    localtime_r(&now, &now_tm);
+    snprintf(hms_buf, sizeof(hms_buf), "%02d:%02d:%02d", now_tm.tm_hour,
+        now_tm.tm_min, now_tm.tm_sec);
+    snprintf(ymdhms_buf, sizeof(ymdhms_buf), "%04d-%02d-%02dT%s",
+        now_tm.tm_year + 1900, now_tm.tm_mon + 1, now_tm.tm_mday, hms_buf);
+
+    /* add timer */
+    g_assert(reader.parse(DIR_TIMER, root) == true);
+    root["scheduledTime"] = ymdhms_buf;
+    g_assert(manager.add(root) == true);
+
+    item = manager.findItem("token-timer");
+    g_assert(item != NULL);
+    g_assert(item->is_activated == true);
+    g_assert(item->is_ignored == false);
+
+    /* add everyday repeat alarm with same time */
+    g_assert(reader.parse(DIR1_EVERYDAY, root) == true);
+    root["scheduledTime"] = hms_buf;
+    g_assert(manager.add(root) == true);
+
+    item = manager.findItem("token-timer");
+    g_assert(item != NULL);
+    g_assert(item->is_activated == true);
+    g_assert(item->is_ignored == true);
+
+    item = manager.findItem("dir1-everyday");
+    g_assert(item != NULL);
+    g_assert(item->is_activated == true);
+    g_assert(item->is_ignored == false);
+}
+
+static void test_ignore2(void)
+{
+    AlertsManager manager;
+    const AlertItem* item;
+    Json::Value root;
+    Json::Reader reader;
+    char hms_buf[32];
+    char ymdhms_buf[64];
+    struct tm now_tm;
+    time_t now;
+
+    now = time(NULL);
+    now += 3;
+
+    localtime_r(&now, &now_tm);
+    snprintf(hms_buf, sizeof(hms_buf), "%02d:%02d:%02d", now_tm.tm_hour,
+        now_tm.tm_min, now_tm.tm_sec);
+    snprintf(ymdhms_buf, sizeof(ymdhms_buf), "%04d-%02d-%02dT%s",
+        now_tm.tm_year + 1900, now_tm.tm_mon + 1, now_tm.tm_mday, hms_buf);
+
+    /* add everyday repeat alarm */
+    g_assert(reader.parse(DIR1_EVERYDAY, root) == true);
+    root["scheduledTime"] = hms_buf;
+    g_assert(manager.add(root) == true);
+
+    item = manager.findItem("dir1-everyday");
+    g_assert(item != NULL);
+    g_assert(item->is_activated == true);
+    g_assert(item->is_ignored == false);
+
+    /* add timer with same time */
+    g_assert(reader.parse(DIR_TIMER, root) == true);
+    root["scheduledTime"] = ymdhms_buf;
+    g_assert(manager.add(root) == true);
+
+    item = manager.findItem("dir1-everyday");
+    g_assert(item != NULL);
+    g_assert(item->is_activated == true);
+    g_assert(item->is_ignored == true);
+
+    item = manager.findItem("token-timer");
+    g_assert(item != NULL);
+    g_assert(item->is_activated == true);
+    g_assert(item->is_ignored == false);
+}
+
+static void test_ignore3(void)
+{
+    AlertsManager manager;
+    const AlertItem* item;
+    Json::Value root;
+    Json::Reader reader;
+    char hms_buf[32];
+    char ymdhms_buf[64];
+    char hms_buf_3secs[32];
+    char ymdhms_buf_3secs[64];
+    struct tm now_tm;
+    time_t now;
+
+    now = time(NULL);
+    now += 3;
+
+    localtime_r(&now, &now_tm);
+    snprintf(hms_buf_3secs, sizeof(hms_buf_3secs), "%02d:%02d:%02d",
+        now_tm.tm_hour, now_tm.tm_min, now_tm.tm_sec);
+    snprintf(ymdhms_buf_3secs, sizeof(ymdhms_buf_3secs), "%04d-%02d-%02dT%s",
+        now_tm.tm_year + 1900, now_tm.tm_mon + 1, now_tm.tm_mday, hms_buf_3secs);
+
+    now = time(NULL);
+    now += 5;
+
+    localtime_r(&now, &now_tm);
+    snprintf(hms_buf, sizeof(hms_buf), "%02d:%02d:%02d", now_tm.tm_hour,
+        now_tm.tm_min, now_tm.tm_sec);
+    snprintf(ymdhms_buf, sizeof(ymdhms_buf), "%04d-%02d-%02dT%s",
+        now_tm.tm_year + 1900, now_tm.tm_mon + 1, now_tm.tm_mday, hms_buf);
+
+    /* add everyday repeat alarm (5secs after) */
+    g_assert(reader.parse(DIR1_EVERYDAY, root) == true);
+    root["scheduledTime"] = hms_buf;
+    g_assert(manager.add(root) == true);
+
+    item = manager.findItem("dir1-everyday");
+    g_assert(item != NULL);
+    g_assert(item->is_activated == true);
+    g_assert(item->is_ignored == false);
+
+    /* add timer (3secs after) */
+    g_assert(reader.parse(DIR_TIMER, root) == true);
+    root["scheduledTime"] = ymdhms_buf_3secs;
+    g_assert(manager.add(root) == true);
+
+    item = manager.findItem("token-timer");
+    g_assert(item != NULL);
+    g_assert(item->is_activated == true);
+    g_assert(item->is_ignored == false);
+
+    /* remove timer */
+    g_assert(manager.removeItem(item->token) == true);
+
+    /* sleep 1 secs to test relative time calculation */
+    sleep(1);
+
+    /* add timer with same time (4secs after) */
+    g_assert(reader.parse(DIR_TIMER, root) == true);
+    root["scheduledTime"] = ymdhms_buf;
+    g_assert(manager.add(root) == true);
+
+    item = manager.findItem("dir1-everyday");
+    g_assert(item != NULL);
+    g_assert(item->is_activated == true);
+    g_assert(item->is_ignored == true);
+
+    item = manager.findItem("token-timer");
+    g_assert(item != NULL);
+    g_assert(item->is_activated == true);
+    g_assert(item->is_ignored == false);
+}
+
 int main(int argc, char* argv[])
 {
 #if !GLIB_CHECK_VERSION(2, 36, 0)
@@ -292,6 +479,9 @@ int main(int argc, char* argv[])
     g_test_add_func("/alarm/simple4", test_simple4);
     g_test_add_func("/alarm/case1", test_case1);
     g_test_add_func("/alarm/case2", test_case2);
+    g_test_add_func("/alarm/ignore1", test_ignore1);
+    g_test_add_func("/alarm/ignore2", test_ignore2);
+    g_test_add_func("/alarm/ignore3", test_ignore3);
 
     return g_test_run();
 }


### PR DESCRIPTION
When an alarm occurs at the same time (alarm + timer), the ignored
event is sent to the server.

Ignored events are allowed in the following states, depending on the
type of alert that has the same time.

- Alarm + Alarm: Not allowed to register duplicated alarm.
- Timer + Timer: Only one timer can be registered.
- Alarm + Timer: Allowed. (Alarm will be ignored)
- Timer + Alarm: Allowed. (Timer will be ignored)

Signed-off-by: Inho Oh <webispy@gmail.com>