### PR TITLE
remove unused hold APIs

### DIFF
--- a/include/alerts_agent.hh
+++ b/include/alerts_agent.hh
@@ -88,10 +88,6 @@ public:
     void setEnable(bool flag);
     bool isEnable();
 
-    void unHoldAlarm();
-    void holdAlarmUntilTextProcess();
-    void unholdAlarmUntilTextProcess();
-
 private:
     void releaseFocus();
     void playSound();
@@ -140,7 +136,6 @@ private:
 
     IAlertsListener* alerts_listener = nullptr;
 
-    bool hold_alarm_by_text;
     bool is_enable;
 
     AlertsManager* manager;

--- a/src/alerts_agent.cc
+++ b/src/alerts_agent.cc
@@ -718,40 +718,6 @@ bool AlertsAgent::isEnable()
     return is_enable;
 }
 
-void AlertsAgent::unHoldAlarm()
-{
-    nugu_info("unHoldAlarm execute");
-    focus_manager->unholdFocus(ALERTS_FOCUS_TYPE);
-}
-
-void AlertsAgent::holdAlarmUntilTextProcess()
-{
-    nugu_info("holdAlarmUntilTextProcess execute");
-    hold_alarm_by_text = true;
-
-    focus_manager->holdFocus(ALERTS_FOCUS_TYPE);
-}
-
-static gboolean _emit_in_idle(gpointer userdata)
-{
-    AlertsAgent* agent = static_cast<AlertsAgent*>(userdata);
-
-    if (agent)
-        agent->unHoldAlarm();
-
-    return FALSE;
-}
-
-void AlertsAgent::unholdAlarmUntilTextProcess()
-{
-    nugu_info("unholdAlarmUntilTextProcess execute");
-
-    if (hold_alarm_by_text && alerts_listener)
-        g_idle_add(_emit_in_idle, this);
-
-    hold_alarm_by_text = false;
-}
-
 void AlertsAgent::playSound()
 {
     if (current == nullptr) {


### PR DESCRIPTION
hold/unhold API in the alerts agent is no more used.

Signed-off-by: Inho Oh <webispy@gmail.com>