### PR TITLE
alerts: fix support for multiple music alarms

### DIFF
--- a/include/alerts_agent.hh
+++ b/include/alerts_agent.hh
@@ -131,7 +131,6 @@ private:
 
     static gboolean onSnoozeAvailabilityTimeout(gpointer userdata);
 
-    NuguCapability::AlertsAudioPlayer* audioplayer;
     std::string playstackctl_ps_id;
     FocusState focus_state;
     NuguDirective* directive_for_sync;
@@ -146,6 +145,7 @@ private:
         std::string token;
         std::string type;
         std::string ps_id;
+        NuguCapability::AlertsAudioPlayer* audioplayer;
     } cur;
 
     std::string active_alarm_token;

--- a/src/alerts_manager.cc
+++ b/src/alerts_manager.cc
@@ -331,6 +331,7 @@ AlertItem* AlertsManager::generateAlert(const Json::Value& json_item)
     item->ps_id = json_item["playServiceId"].asString();
     item->rsrc_type = json_item["alarmResourceType"].asString();
     item->type_str = json_item["alertType"].asString();
+    item->audioplayer = nullptr;
     clock_gettime(CLOCK_REALTIME, &item->creation_time);
 
     if (item->type_str == "ALARM")
@@ -676,6 +677,13 @@ bool AlertsManager::removeItem(const std::string& token)
 
     if (item->is_activated)
         deactivate(item);
+
+    if (item->audioplayer) {
+        nugu_dbg("remove pending audioplayer");
+        item->audioplayer->deInitialize();
+        delete item->audioplayer;
+        item->audioplayer = nullptr;
+    }
 
     delete item;
 

--- a/src/alerts_manager.hh
+++ b/src/alerts_manager.hh
@@ -82,6 +82,8 @@ struct _AlertItem {
     guint timer_src; /* GSource id */
     guint asset_timer_src; /* GSource id */
     guint duration_timer_src; /* GSource id */
+
+    NuguCapability::AlertsAudioPlayer* audioplayer;
 };
 
 class AlertsManager {


### PR DESCRIPTION
When setting multiple music alarms at short intervals, there is a bug
in which the last sound source is played when the first alarm occurs.
so this was fixed.

This occurred because the AlertsAgent uses one audioplayer, and it was
fixed by modifying to have an audioplayer for each alarm.

Signed-off-by: Inho Oh <webispy@gmail.com>