### PR TITLE
fix ALBERTNUGU-1155

### DIFF
--- a/include/alerts_agent.hh
+++ b/include/alerts_agent.hh
@@ -92,6 +92,7 @@ private:
     void releaseFocus();
     void playSound();
     void complete(AlertItem *item, bool start_snooze_timer = true);
+    void addPendingIgnored(AlertItem *item);
 
     /* Events */
     void sendEventCommon(const std::string& ename, const std::string& ps_id, const std::string& token, const std::string& error = "");
@@ -130,6 +131,7 @@ private:
     void onDurationTimeout(const std::string& token) override;
 
     static gboolean onSnoozeAvailabilityTimeout(gpointer userdata);
+    static gboolean onIgnoreTimeout(gpointer userdata);
 
     std::string playstackctl_ps_id;
     FocusState focus_state;
@@ -150,6 +152,8 @@ private:
 
     std::string active_alarm_token;
     guint snooze_availability_timer;
+    std::map<std::string, std::vector<std::string>> ignore_list;
+    guint ignore_timer;
 };
 
 #endif /* __NUGU_ALERTS_AGENT_H__ */


### PR DESCRIPTION
If set the timer at the same time after setting the alarm, the
ignore event is normally sent to the server when the timer occurs,
and a notification is displayed on the mobile app.

However, when setting the alarm at the same time after setting the
timer first, there is an issue that the notification is not
displayed in the mobile app because the deactivated timer is not
included in the context.

To fix the bug, the order of deactivation of items when an ignore
event occurs is changed to after event transmission, and logic
to collect items for 1 second to handle more than two ignores has
been added.

Signed-off-by: Inho Oh <webispy@gmail.com>