### PR TITLE
fix ALBERTNUGU-1264

### DIFF
--- a/src/alerts_agent.cc
+++ b/src/alerts_agent.cc
@@ -568,7 +568,8 @@ void AlertsAgent::parsingSetSnooze(const char* message)
         snooze_availability_timer = 0;
     }
 
-    manager->activate(item);
+    /* Enable the is_activated flag to scheduling (without JSON update) */
+    item->is_activated = true;
     item->snooze_secs = duration_sec;
 
     manager->scheduling();


### PR DESCRIPTION
When receive a snooze request, do not re-activate the alarm item.

It is necessary to set the `is_activated` flag for scheduling,
but the `activation` value of JSON sent to the server should not
be set TRUE.

Signed-off-by: Inho Oh <webispy@gmail.com>