### PR TITLE
fix duration timer to exclude buffering time

### DIFF
--- a/include/alerts_audio_player.hh
+++ b/include/alerts_audio_player.hh
@@ -102,6 +102,8 @@ public:
     bool playTTS();
     bool isTTSPlayer();
 
+    void setRepeat(bool repeat);
+
 private:
     std::string sendEventCommon(const std::string& ename, EventResultCallback cb = nullptr);
 
@@ -135,6 +137,7 @@ private:
     std::string cur_dialog_id;
     bool is_finished;
     std::vector<IAudioPlayerListener*> aplayer_listeners;
+    bool is_repeat;
 
     NuguDirective* cur_ndir;
     bool destroy_directive_by_agent = false;

--- a/src/alerts_audio_player.cc
+++ b/src/alerts_audio_player.cc
@@ -41,6 +41,7 @@ AlertsAudioPlayer::AlertsAudioPlayer()
     , cur_token("")
     , pre_ref_dialog_id("")
     , is_finished(false)
+    , is_repeat(true)
     , cur_ndir(nullptr)
 {
 }
@@ -637,8 +638,11 @@ void AlertsAudioPlayer::mediaEventReport(MediaPlayerEvent event)
         nugu_dbg("PLAYING_MEDIA_FINISHED");
         if (cur_player == media_player) {
             sendEventPlaybackFinished();
-            cur_player->setPosition(0);
-            cur_player->play();
+            if (is_repeat) {
+                nugu_info("Repeat");
+                cur_player->setPosition(0);
+                cur_player->play();
+            }
         } else if (cur_player == tts_player) {
             is_finished = true;
             mediaStateChanged(MediaPlayerState::STOPPED);
@@ -763,6 +767,11 @@ bool AlertsAudioPlayer::isTTSPlayer()
         return true;
 
     return false;
+}
+
+void AlertsAudioPlayer::setRepeat(bool repeat)
+{
+    is_repeat = repeat;
 }
 
 } // NuguCapability


### PR DESCRIPTION
Fixed to restart the duration timer after receiving the
`durationChanged` callback to avoid sending a `Stopped` event
instead of a `Finished` due to the music buffering time.

Signed-off-by: Inho Oh <webispy@gmail.com>